### PR TITLE
Extended test API and basic user API

### DIFF
--- a/api/.idea/.gitignore
+++ b/api/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/api/.idea/api.iml
+++ b/api/.idea/api.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/api/.idea/codeStyles/Project.xml
+++ b/api/.idea/codeStyles/Project.xml
@@ -1,0 +1,28 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JSCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </TypeScriptCodeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="SOFT_MARGINS" value="80" />
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="SOFT_MARGINS" value="80" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/api/.idea/codeStyles/codeStyleConfig.xml
+++ b/api/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/api/.idea/misc.xml
+++ b/api/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/api/.idea/modules.xml
+++ b/api/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/api.iml" filepath="$PROJECT_DIR$/.idea/api.iml" />
+    </modules>
+  </component>
+</project>

--- a/api/.idea/vcs.xml
+++ b/api/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/api/.prettierrc
+++ b/api/.prettierrc
@@ -1,4 +1,5 @@
 {
     "singleQuote": true,
-    "tabWidth": 4
+    "tabWidth": 4,
+    "arrowParens": "avoid"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -16,6 +16,479 @@ To run the server correctly, `.env` file should be created in the root of the `a
 SERVER_PORT = 4000
 DB_CONNECT = mongodb://localhost:27017/test
 TOKEN_SECRET = askjfhlaks
-# 15 min
-TOKEN_EXPIRY_TIME = 15m
+# 6 hours
+TOKEN_EXPIRY_TIME = 6h
+TEST_TOKEN_SECRET = sdkjfhalskjdf
+# 30 min
+TEST_TOKEN_EXPIRY_TIME = 30m
 ```
+
+## API
+Information about the endpoints,
+### Authentication
+* POST `/api/user/register`
+    - body: 
+    ```json
+    {
+       "username":"newUser",
+       "email":"user@new.com",
+       "password":"strong pass"
+    }
+    ```
+    - returns (id of the user in db):
+    ```json
+    {
+       "user":"some id"
+    }
+    ```
+    or status 400 with error
+    
+* POST `/api/user/login`
+    - body:
+    ```json
+    {
+       "email":"user@new.com",
+       "password":"strong pass"
+    }
+    ```
+    - returns (JWT session token)
+    ```json
+    {
+      "token": "some token"
+    }
+    ```
+    or status 400 with error
+    
+    
+### Tests
+* GET `/api/test`
+    - body
+    ```json
+    {
+      "query": "query to search"
+    }
+    ```
+    now, it cannot search by Id of the test
+    - returns array of tests:
+    ```json 
+    {
+      [
+        {
+          ... test here
+        },
+        ...
+      ]
+    }
+    ```
+    or status 400 with error
+    
+* POST `/api/test`  
+    creates a new empty test (without questions)
+    - requirements: registered user
+    - requires being registered user
+    - body:
+    ```json
+    {
+       "name:":"some test name",
+       "description":"test description",
+       "tags":[
+          "tag",
+          "..."
+       ],
+       "category":"some category"
+    }
+    ```
+  - returns the created test:
+    ```json
+    {
+       "_id": "test id",
+       "authors": ["author id", ...],
+       "tags": ["tag1", ...],
+       "description": "...",
+       "questions": [],                           
+       "name": "...",
+       "category": "...",
+       "version": "1.0",
+       "date": "...",
+    }
+    ```
+    or status 400 with error
+    or status 401 when JWT token is bad
+    
+* GET `/api/test/:test_id`  
+    - no body
+    - returns the test with `_id` = `test_id`
+    ```json
+    {
+       "_id": "test id",
+       "authors": ["author id", ...],
+       "tags": ["tag1", ...],
+       "description": "...",
+       "questions": [
+         "question 1 id",
+         "question 2 id",
+         ...   
+       ],                           
+       "name": "...",
+       "category": "...",
+       "version": "1.0",
+       "date": "...",
+    }
+    ```
+    or status 400 with error
+    
+* PUT `/api/test/:test_id`
+    - requirements: registered user, test author
+    updates test values, cannot modify questions array and authors array
+    - body (any element can be skipped):
+    ```json
+    {
+       "name:": "new name",
+       "description": "new description",
+       "tags": ["tag", "new tag", ...],
+       "category": "new category",
+    }
+    ```
+    - returns updated test (see return of GET `/:test_id`) or status 400 with error
+    or status 401 when JWT token is bad
+    
+* DEL `/api/test/:test_id`
+    - requirements: registered user, test author
+    deletes the test with `_id` = `test_id` and all questions associated with it
+    - no body
+    - returns removed test (see return of GET `/:test_id`) or status 400 with error
+    or status 401 when JWT token is bad
+    
+* GET `/api/test/:test_id/questions`
+    - no body
+    - returns questions from the test with `_id` = `test_id`:
+    ```json
+    [
+       {
+          "_id":"question id",
+          "correctAnswers":[
+             id1,
+             id2
+          ],
+          "text":"the question itself",
+          "answers":[
+             {
+                "_id":"some _id",
+                "id":"answer local id",
+                "text":"answer text"
+             },
+             "..."
+          ],
+          "test":"test id"
+       },
+       "..."
+    ]
+    ```
+  
+* GET `/api/test/:test_id/questions/:question_id`
+    - no body
+    - return
+    ```json
+    {
+       "_id":"question id",
+       "correctAnswers":[
+          id1,
+          id2
+       ],
+       "text":"the question itself",
+       "answers":[
+          {
+             "_id":"some _id",
+             "id":"answer local id",
+             "text":"answer text"
+          },
+          "..."
+       ],
+       "test":"test id"
+    },
+    ```
+    or status 400 with error
+    
+* POST `/api/test/:test_id/questions`
+    - requirements: registered user, test author
+    - body:
+    ```json
+    {
+       "text":"question",
+       "correctAnswers":[
+          id1,
+          "..."
+       ],
+       "answers":[
+          {
+             "id": id1,
+             "text":"answer1"
+          },
+          {
+             "id": id2,
+             "text":"answer2"
+          },
+          "..."
+       ]
+    }
+    ```
+    - returns created question:
+    ```json
+    {
+       "_id":"question id",
+       "correctAnswers":[
+          id1,
+          id2
+       ],
+       "text":"the question itself",
+       "answers":[
+          {
+             "_id":"some id",
+             "id":id1,
+             "text":"answer1"
+          },
+          {
+             "_id":"some id",
+             "id":id2,
+             "text":"answer2"
+          },
+          "..."
+       ],
+       "test":"test id"
+    }
+    ```
+    or status 400 with error
+    or status 401 when JWT token is bad
+ 
+* PUT `/api/test/:test_id/questions/:question_id`
+    - requirements: registered user, test author
+    - body (see POST `/:test_id/questions` body) all elements are optional
+    - return updated question (see POST `/:test_id/questions` return) or status 400 with error
+    or status 401 when JWT token is bad
+    
+* DEL `/api/test/:test_id/questions`
+    - requirements: registered user, test author
+    - no body
+    - returns number of deleted question or status 400 with error
+    or status 401 when JWT token is bad
+
+* DEL `/api/test/:test_id/questions/:question_id`
+    - requirements: registered user, test author
+    - no body
+    - returns removed question (see POST `/:test_id/questions` return) or status 400 with error
+    or status 401 when JWT token is bad
+    
+* GET `/api/test/:test_id/authors`
+    - no body
+    - returns array of authors:
+    ```json
+    [
+       {
+          "id":"author id",
+          "name":"author name"
+       }
+    ]
+    ```
+
+* GET `/api/test/:test_id/authors/add`
+    - requirements: registered user, test author
+    - no body
+    - returns token with which other users can assign themselves to be authors of the test with `_id` = `test_id`:
+    ```json
+    {
+      "token": "some JWT token with test information and short expiry time"
+    }
+    ```
+    or status 400
+    or status 401 when JWT token is bad
+
+* PUT `/api/test/authors/add`
+    - requirements: registered user
+    - no body
+    - query: `token: JWT token with test information`
+    - result `"success"` message :D or:
+        - status 404
+        - status 401 if problem with token
+    
+### User
+should this one be restricted to registered users?
+* GET `/api/user`
+    - body (optional):
+    ```json
+    {
+       "query": "search query"
+    }
+    ```
+    - return array of users
+    ```json
+    [
+       {
+          "id":"some id",
+          "username":"some name",
+          "userTests":[
+             {
+                "id":"test_id",
+                "name":"test name",
+                "date":"test creation date"
+             }
+          ]
+       }
+    ]
+    ```
+  
+should this one be restricted to registered users?
+* GET `/api/user/:user_id`
+    - no body
+    - return
+    ```json
+    {
+       "id":"some id",
+       "username":"some name",
+       "userTests":[
+          {
+             "id":"test_id",
+             "name":"test name",
+             "date":"test creation date"
+          },
+          ...
+       ]
+    }
+    ```
+  
+* GET `/api/user/:user_id/user_tests`
+    - no body
+    - returns array of tests, whose author is user:
+    ```json
+    [
+       {
+          "_id":"test id",
+          "name":"test name",
+          "category":"category",
+          "tags":[
+             tag1,
+             tag2
+          ]
+       }
+    ]
+    ```
+
+* GET `/api/user/myself/user_tests`
+    - requirements: registered user
+    - no body
+    - returns array of tests, whose author is user:
+    ```json
+    [
+       {
+          "_id":"test id",
+          "name":"test name",
+          "category":"category",
+          "tags":[
+             tag1,
+             tag2
+          ],
+          "date":"creation date"
+       }
+    ]
+    ```
+    or status 401 when JWT token is bad
+
+* GET `/api/user/myself`
+    - requirements: registered user
+    - no body
+    - return: detailed user:
+    ```json
+    {
+       "_id":"some id",
+       "username":"some name",
+       "userTests":[
+          {
+             "_id":"test_id",
+             "name":"test name",
+             "date":"test creation date"
+          }
+       ],
+       "favouriteTests":[
+          {
+             "_id":"test_id",
+             "name":"test name",
+             "date":"test creation date"
+          }
+       ],
+       "date":"registration date",
+       "email":"user email"
+    }
+    ```
+    or status 401 when JWT token is bad
+  
+* PUT `/api/user/myself/password`  
+    updates user password
+    - requirements: registered user
+    - body:
+    ```json
+    {
+       "oldPassword":"old password",
+       "newPassword":"new password"
+    }
+    ```
+  - return `success` message or 400 status with error
+    or status 401 when JWT token is bad
+  
+* PUT `/api/user/myself/email`
+    - requirements: registered user
+    - body:
+    ```json
+    {
+       "oldEmail":"old@email.com",
+       "newEmail":"new@mail.com"
+    }
+    ```
+    - return:
+    ```json
+    {
+       "email": "new@mail.com"
+    }
+    ```
+    or status 400 with error
+    or status 401 when JWT token is bad
+    
+should we delete the tests created by the user, if there are no other authors?
+* DEL `/api/user/myself`  
+    deletes the user from database
+    - requirements: registered user
+    - no body
+    - returns `success` message
+    or status 401 when JWT token is bad
+
+* GET `/api/user/myself/favourite_tests`
+    - requirements: registered user
+    - no body
+    - returns array of favourite tests:
+    ```json
+    [
+       {
+          "_id":"some id",
+          "name":"some test name",
+          "category":"category",
+          "tags":[
+             tag1,
+             tag2
+          ]
+       },
+       "..."
+    ]
+    ```
+    or status 401 when JWT token is bad
+
+* PUT `/api/user/myself/favourite_tests/:test_id`
+    - requirements: registered user
+    - no body
+    - retruns list of favourite tests ids `{ favouriteTests: [...] }`
+        - status 400 when test does not exist
+        - status 401 when JWT token is bad
+
+* DEL `/api/user/myself/favourite_tests/:test_id`
+    - requirements: registered user
+    - no body
+    - returns `success` message or
+        - 401 message when JWT token is bad
+    

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -2,9 +2,11 @@ const express = require('express');
 const dotenv = require('dotenv');
 const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
+
 // Import routes
 const authRoute = require('./routes/auth');
 const postRoute = require('./routes/test');
+const userRoute = require('./routes/user');
 
 // you will have to create your own .env file in the root of the backend
 // it is not recommended to commit .env files;
@@ -25,6 +27,7 @@ app.use(bodyParser.json());
 // Route Middleware
 app.use('/api/user', authRoute);
 app.use('/api/test', postRoute);
+app.use('/api/user', userRoute);
 
 app.get('/', (req, res) => res.send('Hello, fellow developer!'));
 

--- a/api/src/models/Test.js
+++ b/api/src/models/Test.js
@@ -25,8 +25,14 @@ const testSchema = new mongoose.Schema({
     // invited to create / modify it?
     authors: [
         {
-            type: String,
-            required: true,
+            id: {
+                type: String,
+                required: true,
+            },
+            username: {
+                type: String,
+                required: true,
+            }
         },
     ],
     description: {

--- a/api/src/models/User.js
+++ b/api/src/models/User.js
@@ -19,12 +19,12 @@ const userSchema = new mongoose.Schema({
         max: 1024,
         min: 6,
     },
-    favourite_tests: [
+    favouriteTests: [
         {
             type: String,
         }
     ],
-    user_tests: [String],
+    userTests: [String],
     date: {
         type: Date,
         default: Date.now,

--- a/api/src/models/User.js
+++ b/api/src/models/User.js
@@ -19,28 +19,18 @@ const userSchema = new mongoose.Schema({
         max: 1024,
         min: 6,
     },
-    // NOTE:QUEST: I do not know, if this should be required. I really do not
-    // see this as really needed. However, it either should be `required`,
-    // or if one of these will be entered in client, then the client should
-    // require the other one.
-    firstName: {
-        type: String,
-        required: false,
-        max: 100,
-        min: 2,
-    },
-    lastName: {
-        type: String,
-        required: false,
-        max: 100,
-        min: 2,
-    },
+    favourite_tests: [
+        {
+            type: String,
+        }
+    ],
+    user_tests: [String],
     date: {
         type: Date,
         default: Date.now,
     },
 });
 
-userSchema.index({ username: 'text', firstName: 'text', lastName: 'text' });
+userSchema.index({ username: 'text' });
 
 module.exports = mongoose.model('User', userSchema);

--- a/api/src/routes/auth.js
+++ b/api/src/routes/auth.js
@@ -11,7 +11,7 @@ router.post('/register', async (req, res) => {
     if (error)
         return res
             .status(400)
-            .send(error.details.map((detail) => detail.message));
+            .send(error.details.map(detail => detail.message));
 
     // Check if the email already exists
     const emailExists = await User.findOne({ email: value.email });
@@ -24,7 +24,12 @@ router.post('/register', async (req, res) => {
     // Hash the password
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(value.password, salt);
-    const preparedUser = { ...value, password: hashedPassword };
+    const preparedUser = {
+        ...value,
+        password: hashedPassword,
+        favourite_tests: [],
+        user_tests: [],
+    };
 
     const user = new User(preparedUser);
 
@@ -42,7 +47,7 @@ router.post('/login', async (req, res) => {
     if (error)
         return res
             .status(400)
-            .send(error.details.map((detail) => detail.message));
+            .send(error.details.map(detail => detail.message));
 
     // Check if the email already exists
     const user = await User.findOne({ email: value.email });
@@ -53,10 +58,14 @@ router.post('/login', async (req, res) => {
     if (!validPass) return res.status(400).send('Invalid password');
 
     // create and assign token
-    const token = jwt.sign({ _id: user._id }, process.env.TOKEN_SECRET, {
-        expiresIn: process.env.TOKEN_EXPIRY_TIME,
-        algorithm: 'HS256',
-    });
+    const token = jwt.sign(
+        { id: user._id, username: user.username },
+        process.env.TOKEN_SECRET,
+        {
+            expiresIn: process.env.TOKEN_EXPIRY_TIME,
+            algorithm: 'HS256',
+        }
+    );
 
     res.send({ token });
 });

--- a/api/src/routes/auth.js
+++ b/api/src/routes/auth.js
@@ -27,8 +27,8 @@ router.post('/register', async (req, res) => {
     const preparedUser = {
         ...value,
         password: hashedPassword,
-        favourite_tests: [],
-        user_tests: [],
+        favouriteTests: [],
+        userTests: [],
     };
 
     const user = new User(preparedUser);

--- a/api/src/routes/test.js
+++ b/api/src/routes/test.js
@@ -49,7 +49,7 @@ router.post('/', verifyToken, async (req, res) => {
         const savedTest = await test.save();
         await User.findByIdAndUpdate(
             userId,
-            { $addToSet: { user_tests: [test._id] } },
+            { $addToSet: { userTests: [test._id] } },
             { new: true }
         );
         res.json(savedTest);
@@ -99,11 +99,11 @@ router.delete('/:test_id', verify, async (req, res) => {
         );
         await User.updateMany(
             { id: { $in: authorIds } },
-            { $pull: { user_tests: test._id } }
+            { $pull: { userTests: test._id } }
         ).orFail();
         await User.updateMany(
-            { favourite_tests: test_id },
-            { $pull: { favourite_tests: test_id } }
+            { favouriteTests: test_id },
+            { $pull: { favouriteTests: test_id } }
         ).orFail();
         await Question.deleteMany({ test: test_id }).orFail();
         res.send(test);
@@ -262,7 +262,7 @@ router.put('/authors/add', verifyToken, async (req, res) => {
             { new: true }
         );
         await User.findByIdAndUpdate(user.id, {
-            $addToSet: { user_tests: [testId] },
+            $addToSet: { userTests: [testId] },
         }).orFail();
         res.send('success');
     } catch (err) {

--- a/api/src/routes/test.js
+++ b/api/src/routes/test.js
@@ -1,4 +1,5 @@
 const router = require('express').Router();
+const mongoose = require('mongoose');
 
 const verifyToken = require('../middlewares/verifyToken');
 const verifyAccess = require('../middlewares/verifyTestAccess');
@@ -10,69 +11,14 @@ const { createTestToken, verifyTestToken } = require('../utils/verifyToken');
 
 const verify = [verifyToken, verifyAccess];
 
-// get the whole test
-router.get('/:test_id', async (req, res) => {
-    const { test_id } = req.params;
-    try {
-        const test = await Test.findById(test_id).orFail();
-        res.json(test);
-    } catch (err) {
-        res.status(404).send(err);
-    }
-});
-
-// get all questions in the test
-router.get('/:test_id/questions', async (req, res) => {
-    const { test_id } = req.params;
-    const questions = await Question.find({ test: test_id });
-    res.json(questions);
-});
-
-// get question
-router.get('/:test_id/questions/:question_id', async (req, res) => {
-    const { test_id, question_id } = req.params;
-    try {
-        const question = Question.findOne({
-            _id: question_id,
-            test: test_id,
-        }).orFail();
-        res.json(question);
-    } catch (err) {
-        res.status(400).json({ error: 'No such question in this test' });
-    }
-});
-
-router.get('/:test_id/authors', async (req, res) => {
-    const { test_id } = req.params;
-    try {
-        const { authors: authorIds } = await Test.findById(test_id).orFail();
-        const authors = await Promise.all(
-            authorIds.map(async (userId) => {
-                const user = await User.findById(userId).orFail();
-                return user.username;
-            })
-        );
-        res.send(authors);
-    } catch (err) {
-        res.status(404).send(err);
-    }
-});
+// TESTS
 
 router.get('/', async (req, res) => {
     const { query } = req.body;
 
-    // not sure if this monstrosity works.
     try {
-        // this seems like a good idea to filter the results using the authors indexes
-        // const users = await User.find(
-        //     // i have a feeling, that in extreme cases, this could catch up to hashed password of the user
-        //     { $text: { $search: query } }
-        // ).orFail();
-        // const userIds = users.map((user) => user._id);
         const tests = await Test.find({
             $text: { $search: query },
-            // $or: [{ $text: { $search: query } }, { authors: { $in: userIds } }],
-            // authors: { $in: userIds },
         }).orFail();
 
         res.json(tests);
@@ -84,105 +30,42 @@ router.get('/', async (req, res) => {
 // create new empty test
 router.post('/', verifyToken, async (req, res) => {
     const { error, value } = testCreationValidation(req.body);
+    const { id: userId, username } = req.user;
 
     if (error)
         return res
             .status(400)
-            .send(error.details.map((detail) => detail.message));
+            .send(error.details.map(detail => detail.message));
 
     // initialize new test
     const initializedTest = {
         ...value,
-        authors: value.authors || [req.user._id],
+        authors: [{ id: userId, username }],
         questions: [],
     };
     const test = new Test(initializedTest);
 
     try {
         const savedTest = await test.save();
-        res.json({ test_id: savedTest._id });
-    } catch (err) {
-        res.status(400).send(err);
-    }
-});
-
-// create new question
-router.post('/:test_id/questions', verify, async (req, res) => {
-    const { test_id } = req.params;
-    const { error, value } = questionValidation(req.body);
-
-    if (error)
-        return res
-            .status(400)
-            .send(error.details.map((detail) => detail.message));
-
-    const question = new Question({ ...value, test: test_id });
-
-    try {
-        // it will throw error, if the test_id does not exist, preventing from
-        // storing the question
-        await Test.findOneAndUpdate(
-            { _id: test_id },
-            { $addToSet: { questions: [question._id] } },
-            { new: true }
-        ).orFail();
-        const savedQuestion = await question.save();
-        res.json(savedQuestion._id);
-    } catch (e) {
-        res.status(400).send(e);
-    }
-});
-
-// returns a token that will have to be passed as a query to a link, that will add
-// an existing user who enters the link, to authors of the test, giving permissions
-// to modify it.
-router.get('/:test_id/authors/add', verify, async (req, res) => {
-    const { token_id } = req.params;
-    const token = createTestToken(token_id);
-    res.json({ token });
-});
-
-router.put('/authors/add', verifyToken, async (req, res) => {
-    const { token } = req.query;
-    const { _id: userId } = req.user;
-    const testId = verifyTestToken(token);
-
-    if (!testId) return res.status(404).send();
-
-    try {
-        await Test.findByIdAndUpdate(
-            testId,
-            {
-                $addToSet: { authors: [userId] },
-            },
+        await User.findByIdAndUpdate(
+            userId,
+            { $addToSet: { user_tests: [test._id] } },
             { new: true }
         );
-        res.send('success');
+        res.json(savedTest);
     } catch (err) {
         res.status(400).send(err);
     }
 });
 
-// update question in the test
-router.put('/:test_id/questions/:question_id', verify, async (req, res) => {
-    const { test_id, question_id } = req.params;
-
-    if (req.body._id || req.body.test)
-        return res
-            .status(400)
-            .json({ error: 'tried changing immutable fields' });
-
+// get the test without actual questions
+router.get('/:test_id', async (req, res) => {
+    const { test_id } = req.params;
     try {
-        await Question.findOneAndUpdate(
-            { _id: question_id, test: test_id },
-            req.body,
-            {
-                new: true,
-            }
-        ).orFail();
-        res.send('success');
+        const test = await Test.findById(test_id).orFail();
+        res.json(test);
     } catch (err) {
-        res.status(400).send(err);
+        res.status(404).send(err);
     }
 });
 
@@ -205,11 +88,23 @@ router.put('/:test_id', verify, async (req, res) => {
     }
 });
 
+// deletes the test
 router.delete('/:test_id', verify, async (req, res) => {
     const { test_id } = req.params;
 
     try {
         const test = await Test.findByIdAndDelete(test_id).orFail();
+        const authorIds = test.authors.map(author =>
+            mongoose.Types.ObjectId(author.id)
+        );
+        await User.updateMany(
+            { id: { $in: authorIds } },
+            { $pull: { user_tests: test._id } }
+        ).orFail();
+        await User.updateMany(
+            { favourite_tests: test_id },
+            { $pull: { favourite_tests: test_id } }
+        ).orFail();
         await Question.deleteMany({ test: test_id }).orFail();
         res.send(test);
     } catch (err) {
@@ -217,6 +112,80 @@ router.delete('/:test_id', verify, async (req, res) => {
     }
 });
 
+// QUESTIONS
+
+// get all questions in the test
+router.get('/:test_id/questions', async (req, res) => {
+    const { test_id } = req.params;
+    const questions = await Question.find({ test: test_id });
+    res.json(questions);
+});
+
+// get question
+router.get('/:test_id/questions/:question_id', async (req, res) => {
+    const { test_id, question_id } = req.params;
+    try {
+        const question = Question.findOne({
+            _id: question_id,
+            test: test_id,
+        }).orFail();
+        res.json(question);
+    } catch (err) {
+        res.status(400).json({ error: 'No such question in this test' });
+    }
+});
+
+// create new question
+router.post('/:test_id/questions', verify, async (req, res) => {
+    const { test_id } = req.params;
+    const { error, value } = questionValidation(req.body);
+
+    if (error)
+        return res
+            .status(400)
+            .send(error.details.map(detail => detail.message));
+
+    const question = new Question({ ...value, test: test_id });
+
+    try {
+        // it will throw error, if the test_id does not exist, preventing from
+        // storing the question
+        await Test.findOneAndUpdate(
+            { _id: test_id },
+            { $addToSet: { questions: [question._id] } },
+            { new: true }
+        ).orFail();
+        const savedQuestion = await question.save();
+        res.json(savedQuestion);
+    } catch (e) {
+        res.status(400).send(e);
+    }
+});
+
+// update question in the test
+router.put('/:test_id/questions/:question_id', verify, async (req, res) => {
+    const { test_id, question_id } = req.params;
+
+    if (req.body._id || req.body.test)
+        return res
+            .status(400)
+            .json({ error: 'tried changing immutable fields' });
+
+    try {
+        const question = await Question.findOneAndUpdate(
+            { _id: question_id, test: test_id },
+            req.body,
+            {
+                new: true,
+            }
+        ).orFail();
+        res.send(question);
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+// delete all questions in the test
 router.delete('/:test_id/questions', verify, async (req, res) => {
     const { test_id } = req.params;
 
@@ -231,6 +200,7 @@ router.delete('/:test_id/questions', verify, async (req, res) => {
     }
 });
 
+// removes single question with id
 router.delete('/:test_id/questions/:question_id', verify, async (req, res) => {
     const { test_id, question_id } = req.params;
 
@@ -244,5 +214,61 @@ router.delete('/:test_id/questions/:question_id', verify, async (req, res) => {
         res.status(400).send(err);
     }
 });
+
+
+// returns authors of the test we should find a way to remove them if necessary,
+// but should any from the authors remove any other?
+router.get('/:test_id/authors', async (req, res) => {
+    const { test_id } = req.params;
+    try {
+        const { authors: authorIds } = await Test.findById(test_id).orFail();
+        const authors = await Promise.all(
+            authorIds.map(async userId => {
+                const user = await User.findById(userId).orFail();
+                return ({ id: userId, username: user.username });
+            })
+        );
+        res.send(authors);
+    } catch (err) {
+        res.status(404).send();
+    }
+});
+
+// returns a token that will have to be passed as a query to a link, that will add
+// an existing user who enters the link, to authors of the test, giving permissions
+// to modify it.
+router.get('/:test_id/authors/add', verify, async (req, res) => {
+    const { test_id } = req.params;
+    const token = createTestToken(test_id);
+    res.json({ token });
+});
+
+// adds a user with valid test token to the authors of the test
+// it will allow him / her / (insert whoever you feel like here)
+// to modify the test
+router.put('/authors/add', verifyToken, async (req, res) => {
+    const { token } = req.query;
+    const { user } = req;
+    const testId = verifyTestToken(token);
+
+    if (!testId) return res.status(404).send();
+
+    try {
+        await Test.findByIdAndUpdate(
+            testId,
+            {
+                $addToSet: { authors: [user] },
+            },
+            { new: true }
+        );
+        await User.findByIdAndUpdate(user.id, {
+            $addToSet: { user_tests: [testId] },
+        }).orFail();
+        res.send('success');
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
 
 module.exports = router;

--- a/api/src/routes/users.js
+++ b/api/src/routes/users.js
@@ -1,0 +1,255 @@
+const router = require('express').Router();
+
+const verifyToken = require('../middlewares/verifyToken');
+const Test = require('../models/Test');
+const User = require('../models/User');
+
+
+router.get('/', async (req, res) => {
+    const { query } = req.body;
+    const searchQuery =
+        !query || query === '' ? {} : { $text: { $search: query } };
+
+    try {
+        const users = await User.find(searchQuery).orFail();
+        const returnUsers = await Promise.all(
+            users.map(async user => ({
+                id: user._id,
+                username: user.username,
+                userTests: user.userTests.map(async testId => {
+                    const test = await Test.findById(testId).orFail();
+                    return {
+                        id: test._id,
+                        name: test.name,
+                        category: test.category,
+                        tags: test.tags,
+                        date: test.date,
+                    };
+                }),
+            }))
+        );
+
+        res.send(returnUsers);
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+router.get('/:user_id', async (req, res) => {
+    const { user_id } = req.params;
+
+    try {
+        const user = await User.findById(user_id).orFail();
+        const userTests = await Promise.all(
+            user.userTests.map(async testId => {
+                const test = await Test.findById(testId).orFail();
+                return {
+                    id: test.id,
+                    name: test.name,
+                    category: test.category,
+                    tags: test.tags,
+                    date: test.date,
+                };
+            })
+        );
+        const returnUser = { id: user._id, username: user.username, userTests };
+
+        res.send(returnUser);
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+// returns tests to which the user has rights to modify -> is one of authors
+router.get('/:user_id/user_tests', async (req, res) => {
+    const { user_id } = req.params;
+
+    try {
+        const user = await User.findById(user_id).orFail();
+        const userTestIds = user.user_tests;
+        const userTests = await Test.find({
+            _id: {
+                $in: userTestIds.map(testId => mongoose.Types.ObjectId(testId)),
+            },
+        }).orFail();
+
+        const tests = userTests.map(test => ({
+            id: test._id,
+            name: test.name,
+            category: test.category,
+            tags: test.tags,
+        }));
+
+        res.json(tests);
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+// returns tests to which the user has rights to modify -> is one of authors
+router.get('/myself/user_tests', verifyToken, async (req, res) => {
+    const { id: userId } = req.user;
+
+    try {
+        const user = await User.findById(userId).orFail();
+        const userTestIds = user.user_tests;
+        const userTests = await Test.find({
+            _id: {
+                $in: userTestIds.map(testId => mongoose.Types.ObjectId(testId)),
+            },
+        }).orFail();
+
+        const tests = userTests.map(test => ({
+            id: test._id,
+            name: test.name,
+            category: test.category,
+            tags: test.tags,
+            date: test.date,
+        }));
+
+        res.json(tests);
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+router.get('/myself', verifyToken, async (req, res) => {
+    const { id: userId } = req.user;
+
+    try {
+        const user = User.findById(userId).orFail();
+        user.delete(password);
+        res.send(user);
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+router.put('/myself/password', verifyToken, async (req, res) => {
+    const { id: userId } = req.user;
+    const { oldPassword, newPassword } = req.body;
+
+    try {
+        const user = User.findById(userId).orFail();
+
+        const validPass = await bcrypt.compare(oldPassword, user.password);
+        if (!validPass) return res.status(400).send('Invalid password');
+
+        const salt = await bcrypt.genSalt(10);
+        const newHashedPassword = await bcrypt.hash(newPassword, salt);
+
+        await User.findByIdAndUpdate(userId, {
+            password: newHashedPassword,
+        }).orFail();
+
+        res.send('success');
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+router.put('/myself/email', verifyToken, async (req, res) => {
+    const { id: userId } = req.user;
+    const { oldEmail, newEmail } = req.body;
+
+    try {
+        const user = User.findById(userId).orFail();
+
+        if (user.email !== oldEmail)
+            return res.status(400).send('Invalid email');
+
+        await User.findByIdAndUpdate(userId, { email: newEmail });
+
+        res.json({ email: newEmail });
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+router.delete('/myself', verifyToken, async (req, res) => {
+    const { id: userId } = req.user;
+
+    try {
+        await User.findByIdAndRemove(userId).orFail();
+
+        res.send('success');
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+// returns users favourite tests, works only with registered user
+router.get('/myself/favourite_tests', verifyToken, async (req, res) => {
+    const { id: userId } = req.user;
+
+    try {
+        const user = await User.findById(userId).orFail();
+        const favouriteTestIds = user.favourite_tests;
+        const favouriteTests = await Test.find({
+            _id: {
+                $in: favouriteTestIds.map(testId =>
+                    mongoose.Types.ObjectId(testId)
+                ),
+            },
+        }).orFail();
+
+        const tests = favouriteTests.map(test => ({
+            id: test._id,
+            name: test.name,
+            category: test.category,
+            tags: test.tags,
+        }));
+
+        res.json(tests);
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+// add test to users favourite
+router.put(
+    '/myself/favourite_tests/:test_id',
+    verifyToken,
+    async (req, res) => {
+        const { id: userId } = req.user;
+        const { test_id } = req.params;
+
+        try {
+            // check if the test actually exists, so we do not add phantom tests.
+            await Test.findById(test_id).orFail();
+            const user = await User.findByIdAndUpdate(
+                userId,
+                { $addToSet: { favourite_tests: [test_id] } },
+                { new: true }
+            ).orFail();
+
+            res.send(user.favourite_tests);
+        } catch (err) {
+            res.status(400).send(err);
+        }
+    }
+);
+
+// remove test with id from favourites
+router.delete(
+    '/myself/favourite_tests/:test_id',
+    verifyToken,
+    async (req, res) => {
+        const { test_id } = req.params;
+        const { id: userId } = req.user;
+
+        try {
+            // no need to check if the test exists, since we just remove its id from
+            // user's array
+            const user = await User.findByIdAndUpdate(userId, {
+                $pull: { favourite_tests: test_id },
+            }).orFail();
+
+            res.send('success');
+        } catch (err) {
+            res.status(400).send(err);
+        }
+    }
+);
+
+module.exports = router;

--- a/api/src/validate.js
+++ b/api/src/validate.js
@@ -1,12 +1,10 @@
 const Joi = require('@hapi/joi');
 
-const registerValidation = (data) => {
+const registerValidation = data => {
     const schema = Joi.object({
         username: Joi.string().min(2).required(),
         email: Joi.string().min(6).required().email(),
         password: Joi.string().min(6).required(),
-        firstName: Joi.string().min(2).max(100),
-        lastName: Joi.string().min(2).max(100),
     });
 
     return schema.validate(data, {
@@ -14,7 +12,7 @@ const registerValidation = (data) => {
     });
 };
 
-const loginValidation = (data) => {
+const loginValidation = data => {
     const schema = Joi.object({
         // TODO: decide how the user will log in, whether we will use username / login
         // or email.
@@ -28,7 +26,7 @@ const loginValidation = (data) => {
     });
 };
 
-const testCreationValidation = (data) => {
+const testCreationValidation = data => {
     const schema = Joi.object({
         name: Joi.string().max(128).required(),
         version: Joi.string().min(1).max(50).default('1.0'),
@@ -42,7 +40,7 @@ const testCreationValidation = (data) => {
     });
 };
 
-const questionValidation = (data) => {
+const questionValidation = data => {
     const schema = Joi.object({
         text: Joi.string().required(),
         answers: Joi.array()


### PR DESCRIPTION
I have made a basic user API, which technically should work.
I have listed the current endpoints and gave some information about it in README file.

There are some limitations due to how mongodb handles text search - it can search only by full words that match - so `te` will not match `test`. There probably are a few better or worse ways to hack around it. If you happen to know how to do it or did it in the past, feel free to code it.

The code will probably be refactored, but for now a working version should be good enough not to stop the frontend.

The way endpoints work will most likely no be changed, unless we decide to do so.